### PR TITLE
[JavaScript] 計算できなかった場合に中置記法の表示でTypeErrorになる

### DIFF
--- a/src/impls/javascript/polish.js
+++ b/src/impls/javascript/polish.js
@@ -356,7 +356,7 @@ function polish_main(_expression) {
     else {
       // (式の一部あるいは全部が)計算できなかった場合は、計算結果の式を中置記法で表示する
       process.stdout.write("calculated expression: ");
-      root.traverseInorder();
+      root.traverseInorder(process.stdout);
       process.stdout.write("\n");
     }
   }


### PR DESCRIPTION
数式が計算できなかった場合に中置記法の表示でTypeErrorになる。

```
input expression: expression: (2*3)/2(1+2)
reverse polish notation: 2 3 * 2(1+2) / 
infix notation: ((2 * 3) / 2(1+2))
polish notation: / * 2 3 2(1+2) 
calculated expression:
TypeError: Cannot read properties of undefined (reading 'write')
    at Node.traverseInorder (/home/runner/work/polish-notation-impls/polish-notation-impls/src/impls/javascript/polish.js:203:14)
    at polish_main (/home/runner/work/polish-notation-impls/polish-notation-impls/src/impls/javascript/polish.js:359:12)
    at Interface.<anonymous> (/home/runner/work/polish-notation-impls/polish-notation-impls/src/impls/javascript/polish.js:314:7)
    at Interface.emit (node:events:513:28)
    at [_onLine] [as _onLine] (node:internal/readline/interface:425:12)
    at [_line] [as _line] (node:internal/readline/interface:886:18)
    at [_ttyWrite] [as _ttyWrite] (node:internal/readline/interface:1273:24)
    at Socket.onkeypress (node:internal/readline/interface:273:20)
    at Socket.emit (node:events:513:28)
    at emitKeys (node:internal/readline/utils:357:14)
```

`Node.traverseInorder`に`process.stdout`が渡されていないため、渡すように修正。