### PR TITLE
文字列化に際する浮動小数点の精度を上げる

### DIFF
--- a/src/impls/c/polish.c
+++ b/src/impls/c/polish.c
@@ -299,10 +299,10 @@ int calculate(Node* node)
     // ノードの演算子に応じて左右の子ノードの値を演算し、
     // 演算した結果を文字列に変換して再度node->expに代入することで現在のノードの値とする
     switch (node->exp[0]) {
-      case '+': snprintf(node->exp, MAX_EXP_LEN, "%.15lg", left_operand + right_operand); break;
-      case '-': snprintf(node->exp, MAX_EXP_LEN, "%.15lg", left_operand - right_operand); break;
-      case '*': snprintf(node->exp, MAX_EXP_LEN, "%.15lg", left_operand * right_operand); break;
-      case '/': snprintf(node->exp, MAX_EXP_LEN, "%.15lg", left_operand / right_operand); break;
+      case '+': snprintf(node->exp, MAX_EXP_LEN, "%.17g", left_operand + right_operand); break;
+      case '-': snprintf(node->exp, MAX_EXP_LEN, "%.17g", left_operand - right_operand); break;
+      case '*': snprintf(node->exp, MAX_EXP_LEN, "%.17g", left_operand * right_operand); break;
+      case '/': snprintf(node->exp, MAX_EXP_LEN, "%.17g", left_operand / right_operand); break;
       // 上記以外の演算子の場合は計算できないものとして、-1(失敗)を返す
       default: return -1;
     }

--- a/src/impls/csharp/polish.cs
+++ b/src/impls/csharp/polish.cs
@@ -271,10 +271,10 @@ class Node {
     // 現在のノードの演算子に応じて左右の子ノードの値を演算し、
     // 演算した結果を文字列に変換して再度Expressionに代入することで現在のノードの値とする
     switch (Expression[0]) {
-      case '+': Expression = (leftOperand + rightOperand).ToString("g15"); break;
-      case '-': Expression = (leftOperand - rightOperand).ToString("g15"); break;
-      case '*': Expression = (leftOperand * rightOperand).ToString("g15"); break;
-      case '/': Expression = (leftOperand / rightOperand).ToString("g15"); break;
+      case '+': Expression = (leftOperand + rightOperand).ToString("g17"); break;
+      case '-': Expression = (leftOperand - rightOperand).ToString("g17"); break;
+      case '*': Expression = (leftOperand * rightOperand).ToString("g17"); break;
+      case '/': Expression = (leftOperand / rightOperand).ToString("g17"); break;
       // 上記以外の演算子の場合は計算できないものとして、falseを返す
       default: return false;
     }

--- a/src/impls/java/Polish.java
+++ b/src/impls/java/Polish.java
@@ -303,7 +303,7 @@ class Node {
     // 演算結果の数値を文字列化するためのメソッド
     private String formatNumber(double number)
     {
-        return (new DecimalFormat("#.###############")).format(number);
+        return (new DecimalFormat("#.#################")).format(number);
     }
 }
 

--- a/src/impls/javascript/polish.js
+++ b/src/impls/javascript/polish.js
@@ -294,7 +294,7 @@ class Node {
     let nf = new Intl.NumberFormat("en", {
       style: "decimal",
       minimumSignificantDigits: 1,
-      maximumSignificantDigits: 15,
+      maximumSignificantDigits: 17,
       useGrouping: false,
     });
 

--- a/src/impls/python/polish.py
+++ b/src/impls/python/polish.py
@@ -253,13 +253,13 @@ class Node:
     # 現在のノードの演算子に応じて左右の子ノードの値を演算し、
     # 演算した結果を文字列に変換して再度expressionに代入することで現在のノードの値とする
     if self.expression[0] == "+":
-      self.expression = "{:.15g}".format(left_operand + right_operand)
+      self.expression = "{:.17g}".format(left_operand + right_operand)
     elif self.expression[0] == "-":
-      self.expression = "{:.15g}".format(left_operand - right_operand)
+      self.expression = "{:.17g}".format(left_operand - right_operand)
     elif self.expression[0] == "*":
-      self.expression = "{:.15g}".format(left_operand * right_operand)
+      self.expression = "{:.17g}".format(left_operand * right_operand)
     elif self.expression[0] == "/":
-      self.expression = "{:.15g}".format(left_operand / right_operand)
+      self.expression = "{:.17g}".format(left_operand / right_operand)
     else:
       # 上記以外の演算子の場合は計算できないものとして、Falseを返す
       return False

--- a/src/impls/visualbasic/polish.vb
+++ b/src/impls/visualbasic/polish.vb
@@ -251,10 +251,10 @@ Class Node
     ' 現在のノードの演算子に応じて左右の子ノードの値を演算し、
     ' 演算した結果を文字列に変換して再度Expressionに代入することで現在のノードの値とする
     Select Case Expression(0)
-      Case "+"c: Expression = (leftOperand + rightOperand).ToString("g15")
-      Case "-"c: Expression = (leftOperand - rightOperand).ToString("g15")
-      Case "*"c: Expression = (leftOperand * rightOperand).ToString("g15")
-      Case "/"c: Expression = (leftOperand / rightOperand).ToString("g15")
+      Case "+"c: Expression = (leftOperand + rightOperand).ToString("g17")
+      Case "-"c: Expression = (leftOperand - rightOperand).ToString("g17")
+      Case "*"c: Expression = (leftOperand * rightOperand).ToString("g17")
+      Case "/"c: Expression = (leftOperand / rightOperand).ToString("g17")
       ' 上記以外の演算子の場合は計算できないものとして、Falseを返す
       Case Else: Return False
     End Select

--- a/tests/impls/testcases/calculable-expressions.jsonc
+++ b/tests/impls/testcases/calculable-expressions.jsonc
@@ -38,25 +38,23 @@
     { "Input": "1/4",   "ExpectedCalculationResult": "0.25" },
     { "Input": "1/8",   "ExpectedCalculationResult": "0.125" },
 
-    // test cases for floating point formatting equivalent to '%.15g' of C printf
-    { "Input": "1/3",   "ExpectedCalculationResult": "0.333333333333333", "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
-    { "Input": "2/3",   "ExpectedCalculationResult": "0.666666666666667", "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
-    { "Input": "10000000000000000/1",           "ExpectedCalculationResult": "1e+16",   "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
-    { "Input": "1/10000000000000000",           "ExpectedCalculationResult": "1e-16",   "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
-    { "Input": "99999999999999999/1",           "ExpectedCalculationResult": "1e+17",   "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
-    { "Input": "(3/2)*(10000000000000000/1)",   "ExpectedCalculationResult": "1.5e+16", "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
-    { "Input": "(3/2)/(10000000000000000/1)",   "ExpectedCalculationResult": "1.5e-16", "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
+    // test cases for floating point formatting equivalent to '%.17g' of C printf
+    { "Input": "1/3",   "ExpectedCalculationResult": "0.33333333333333331", "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
+    { "Input": "2/3",   "ExpectedCalculationResult": "0.66666666666666663", "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
+    { "Input": "10000000000000000/1",           "ExpectedCalculationResult": "10000000000000000",       "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
+    { "Input": "1/10000000000000000",           "ExpectedCalculationResult": "9.9999999999999998e-17",  "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
+    { "Input": "99999999999999999/1",           "ExpectedCalculationResult": "1e+17",                   "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
+    { "Input": "(3/2)*(10000000000000000/1)",   "ExpectedCalculationResult": "15000000000000000",       "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
+    { "Input": "(3/2)/(10000000000000000/1)",   "ExpectedCalculationResult": "1.5e-16",                 "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
 
-    // test cases for floating point formatting specific to Intl.NumberFormat and/or java.text.NumberFormat
-    { "Input": "1/3",   "ExpectedCalculationResult": "0.333333333333333", "TargetImplementations": [ "java", "javascript" ] },
-    { "Input": "2/3",   "ExpectedCalculationResult": "0.666666666666667", "TargetImplementations": [ "java", "javascript" ] },
+    // test cases for floating point formatting specific to Intl.NumberFormat and/or java.text.NumberFormat (maximumSignificantDigits = 17)
+    { "Input": "1/3",   "ExpectedCalculationResult": "0.3333333333333333", "TargetImplementations": [ "java", "javascript" ] },
+    { "Input": "2/3",   "ExpectedCalculationResult": "0.6666666666666666", "TargetImplementations": [ "java", "javascript" ] },
     { "Input": "10000000000000000/1",           "ExpectedCalculationResult": "10000000000000000",   "TargetImplementations": [ "java", "javascript" ] },
-    { "Input": "1/10000000000000000",           "ExpectedCalculationResult": "0",                   "TargetImplementations": [ "java" ] },
+    { "Input": "1/10000000000000000",           "ExpectedCalculationResult": "0.0000000000000001",  "TargetImplementations": [ "java", "javascript" ] },
     { "Input": "99999999999999999/1",           "ExpectedCalculationResult": "100000000000000000",  "TargetImplementations": [ "java", "javascript" ] },
-    { "Input": "1/10000000000000000",           "ExpectedCalculationResult": "0.0000000000000001",  "TargetImplementations": [ "javascript" ] },
     { "Input": "(3/2)*(10000000000000000/1)",   "ExpectedCalculationResult": "15000000000000000",   "TargetImplementations": [ "java", "javascript" ] },
-    { "Input": "(3/2)/(10000000000000000/1)",   "ExpectedCalculationResult": "0",                   "TargetImplementations": [ "java" ] },
-    { "Input": "(3/2)/(10000000000000000/1)",   "ExpectedCalculationResult": "0.00000000000000015", "TargetImplementations": [ "javascript" ] },
+    { "Input": "(3/2)/(10000000000000000/1)",   "ExpectedCalculationResult": "0.00000000000000015", "TargetImplementations": [ "java", "javascript" ] },
 
     /*
      * expression which contains space

--- a/tests/impls/testcases/calculable-expressions.jsonc
+++ b/tests/impls/testcases/calculable-expressions.jsonc
@@ -41,6 +41,7 @@
     // test cases for floating point formatting equivalent to '%.17g' of C printf
     { "Input": "1/3",   "ExpectedCalculationResult": "0.33333333333333331", "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
     { "Input": "2/3",   "ExpectedCalculationResult": "0.66666666666666663", "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
+    { "Input": "1/7",   "ExpectedCalculationResult": "0.14285714285714285", "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
     { "Input": "10000000000000000/1",           "ExpectedCalculationResult": "10000000000000000",       "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
     { "Input": "1/10000000000000000",           "ExpectedCalculationResult": "9.9999999999999998e-17",  "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
     { "Input": "99999999999999999/1",           "ExpectedCalculationResult": "1e+17",                   "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
@@ -48,8 +49,9 @@
     { "Input": "(3/2)/(10000000000000000/1)",   "ExpectedCalculationResult": "1.5e-16",                 "TargetImplementations": [ "c", "csharp", "python", "visualbasic" ] },
 
     // test cases for floating point formatting specific to Intl.NumberFormat and/or java.text.NumberFormat (maximumSignificantDigits = 17)
-    { "Input": "1/3",   "ExpectedCalculationResult": "0.3333333333333333", "TargetImplementations": [ "java", "javascript" ] },
-    { "Input": "2/3",   "ExpectedCalculationResult": "0.6666666666666666", "TargetImplementations": [ "java", "javascript" ] },
+    { "Input": "1/3",   "ExpectedCalculationResult": "0.3333333333333333",  "TargetImplementations": [ "java", "javascript" ] },
+    { "Input": "2/3",   "ExpectedCalculationResult": "0.6666666666666666",  "TargetImplementations": [ "java", "javascript" ] },
+    { "Input": "1/7",   "ExpectedCalculationResult": "0.14285714285714285", "TargetImplementations": [ "java", "javascript" ] },
     { "Input": "10000000000000000/1",           "ExpectedCalculationResult": "10000000000000000",   "TargetImplementations": [ "java", "javascript" ] },
     { "Input": "1/10000000000000000",           "ExpectedCalculationResult": "0.0000000000000001",  "TargetImplementations": [ "java", "javascript" ] },
     { "Input": "99999999999999999/1",           "ExpectedCalculationResult": "100000000000000000",  "TargetImplementations": [ "java", "javascript" ] },


### PR DESCRIPTION
浮動小数点の文字列化に際して使用する書式を`%.15g`から`%.17g`(およびその相当書式)に変更する。

参考: https://qiita.com/dankogai/items/a333bed751e4b0a71975