### PR TITLE
[Python] 型ヒントを付ける

### DIFF
--- a/.github/workflows/run-tests-impls.yml
+++ b/.github/workflows/run-tests-impls.yml
@@ -142,6 +142,10 @@ jobs:
         if: ${{ runner.os == 'Windows' && matrix.target-impl == 'cpp' }}
         uses: microsoft/setup-msbuild@v1.3
 
+      - name: Setup mypy
+        if: ${{ matrix.target-impl == 'python' }}
+        run: pip install mypy
+
       - name: Run tests with ${{ matrix.target-impl }} on ${{ matrix.os }}
         shell: pwsh
         run: |

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "editorconfig.editorconfig",
     "ms-dotnettools.csharp",
+    "ms-python.mypy-type-checker",
     "ms-vscode.cpptools"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,6 +46,7 @@
     "streambuf": "cpp",
     "typeinfo": "cpp"
   },
+  "mypy-type-checker.args": ["--config-file=${workspaceFolder}/mypy.ini"],
   "[jsonc]": {
     "editor.formatOnSave": false,
     "editor.formatOnType": false,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+# SPDX-License-Identifier: MIT
+# cSpell:ignore mypy
+[mypy]
+python_version = 3.12
+
+strict = true
+
+show_error_codes = true
+
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_globals = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+
+no_implicit_optional = true
+
+warn_return_any = true
+warn_unused_ignores = true
+warn_unreachable = true

--- a/src/impls/python/Makefile
+++ b/src/impls/python/Makefile
@@ -1,0 +1,15 @@
+MYPY = mypy --config-file ../../../mypy.ini
+
+all: type-check run
+
+type-check:
+	$(MYPY) polish.py
+
+run:
+	@if [ -z "${INPUT}" ]; then \
+		./polish.py; \
+	fi
+
+	@if [ -n "${INPUT}" ]; then \
+		echo ${INPUT} | ./polish.py; \
+	fi

--- a/src/impls/python/README.md
+++ b/src/impls/python/README.md
@@ -16,3 +16,6 @@ infix notation: ((2 + (5 * 3)) - 4)
 polish notation: - + 2 * 5 3 4
 calculated result: 13
 ```
+
+# 型チェック
+型ヒントの検証を行う場合は、`make type-check`を実行してください。　なお、`mypy`がインストールされている必要があります。

--- a/tests/impls/implementations.jsonc
+++ b/tests/impls/implementations.jsonc
@@ -95,6 +95,17 @@
     }
   },
   {
+    "ImplementationId": "python",
+    "DisplayName": "Python 3 with type annotations",
+    "Directory": "src/impls/python/",
+    "Condition": "[bool](Get-Command make -errorAction SilentlyContinue)",
+    "Commands": {
+      "Build":  [ { "Command": "make", "Arguments": [ "type-check" ] } ],
+      "Clean":  [ ],
+      "Run":    { "Command": "python3", "Arguments": [ "polish.py" ] },
+    }
+  },
+  {
     "ImplementationId": "visualbasic",
     "DisplayName": "Visual Basic",
     "Directory": "src/impls/visualbasic/",

--- a/tests/impls/run-tests.ps1
+++ b/tests/impls/run-tests.ps1
@@ -66,7 +66,12 @@ function Invoke-Tests {
         Invoke-Expression "$($cmd.Command) $($cmd.Arguments -join ' ')"
       }
       else {
-        [void]$(& $cmd.Command $cmd.Arguments)
+        & $cmd.Command $cmd.Arguments 2>&1 | ForEach-Object { Write-Host $_ }
+
+        if ($LASTEXITCODE -ne 0) {
+          $done_build = $false
+          break
+        }
       }
     }
     catch {


### PR DESCRIPTION
### Fixes issue
Fixes #11

### Description
Python 3.12に対応する型ヒントをつける。

これに伴い、型チェックのために推奨VSCode拡張としてMypy Type Checkerを追加する。
また、同拡張用の設定ファイル`mypy.ini`も追加する。

### Testing
テストに際して、mypyコマンドによる型ヒントの検証を行うようにする。
