### PR TITLE
std::stodの代わりにstd::from_charsを使用する

### DIFF
--- a/src/impls/cpp/polish.cpp
+++ b/src/impls/cpp/polish.cpp
@@ -72,7 +72,7 @@ private:
     // 与えられた文字列を数値化するメソッド
     // 正常に変換できた場合はnumberに変換した数値を代入し、trueを返す
     // 変換できなかった場合はfalseを返す
-    static bool parse_number(const std::string& expression, double& number);
+    static bool parse_number(const std::string_view& expression, double& number) noexcept;
 };
 
 // 与えられた式が不正な形式であることを報告するための例外クラス
@@ -392,25 +392,18 @@ void Node::calculate_node(Node& node)
     node.right = nullptr;
 }
 
-bool Node::parse_number(const std::string& expression, double& number)
+bool Node::parse_number(const std::string_view& expression, double& number) noexcept
 {
-    try {
-        size_t pos_invalid; // std::stodで変換できない文字の位置を検出するための変数
+    // 与えられた文字列を数値に変換する
+    [[maybe_unused]] auto [ptr, ec] = std::from_chars(
+        std::to_address(std::begin(expression)),
+        std::to_address(std::end(expression)),
+        number
+    );
 
-        // 与えられた文字列を数値に変換する
-        number = std::stod(expression, &pos_invalid);
-
-        if (pos_invalid < expression.length())
-            return false; // 途中に変換できない文字があるため、正常に変換できなかった
-
-        return true;
-    }
-    catch (std::out_of_range&) {
-        return false;// doubleで扱える範囲外のため、正常に変換できなかった
-    }
-    catch (std::invalid_argument&) {
-        return false; // doubleに変換できないため、正常に変換できなかった
-    }
+    // 最後の文字まで変換できた場合は、正常に変換できたと判断する
+    // そうでなければ、正常に変換できなかったと判断する
+    return ptr == std::to_address(std::end(expression));
 }
 
 std::string Node::format_number(const double& number) noexcept


### PR DESCRIPTION
### Description
文字列から数値への変換において、`std::stod`の代わりに`std::from_chars`を使用する。
これによって、例外ハンドリングの必要がない実装に簡略化する。

同時に、引数の型を`std::string`から`std::string_view`に変える。

ただし、GitHub Actions macOSランナーイメージのデフォルトのツールセットでは、まだ`std::from_chars`が`double`への変換をサポートしていないようなので、サポートされ次第マージする。

### Considerations
以下のように、まだ`std::from_chars`がサポートされていないので、デフォルトのツールセットでコンパイルできるようになるまでマージを控える。

```
Run tests with an implementation of C++ (GitHub Actions, make + G++) ...
Apple clang version 17.0.0 (clang-1700.0.13.5)
Target: arm64-apple-darwin24.6.0
Thread model: posix
InstalledDir: /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
g++ -std=c++2a -O2 -Wall -c polish.cpp
polish.cpp:398:39: error: call to deleted function 'from_chars'
  398 |     [[maybe_unused]] auto [ptr, ec] = std::from_chars(
      |                                       ^~~~~~~~~~~~~~~
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__charconv/from_chars_integral.h:38:19: note: candidate function has been explicitly deleted
   38 | from_chars_result from_chars(const char*, const char*, bool, int = 10) = delete;
      |                   ^
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__charconv/from_chars_integral.h:224:1: note: candidate template ignored: requirement 'is_integral<double>::value' was not satisfied [with _Tp = double]
  224 | from_chars(const char* __first, const char* __last, _Tp& __value) {
      | ^
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__charconv/from_chars_integral.h:230:1: note: candidate function template not viable: requires 4 arguments, but 3 were provided
  230 | from_chars(const char* __first, const char* __last, _Tp& __value, int __base) {
      | ^          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make: *** [polish.o] Error 1
```

```
Run tests with an implementation of C++ (GitHub Actions, make + Clang) ...
Apple clang version 17.0.0 (clang-1700.0.13.5)
Target: arm64-apple-darwin24.6.0
Thread model: posix
InstalledDir: /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
clang++ -std=c++2a -O2 -Wall -c polish.cpp
polish.cpp:398:39: error: call to deleted function 'from_chars'
  398 |     [[maybe_unused]] auto [ptr, ec] = std::from_chars(
      |                                       ^~~~~~~~~~~~~~~
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__charconv/from_chars_integral.h:38:19: note: candidate function has been explicitly deleted
   38 | from_chars_result from_chars(const char*, const char*, bool, int = 10) = delete;
      |                   ^
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__charconv/from_chars_integral.h:224:1: note: candidate template ignored: requirement 'is_integral<double>::value' was not satisfied [with _Tp = double]
  224 | from_chars(const char* __first, const char* __last, _Tp& __value) {
      | ^
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__charconv/from_chars_integral.h:230:1: note: candidate function template not viable: requires 4 arguments, but 3 were provided
  230 | from_chars(const char* __first, const char* __last, _Tp& __value, int __base) {
      | ^          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make: *** [polish.o] Error 1
```

```
Operating System
  macOS
  15.7.3
  24G419
Runner Image
  Image: macos-15-arm64
  Version: 20260105.0094.1
  Included Software: https://github.com/actions/runner-images/blob/macos-15-arm64/20260105.0094/images/macos/macos-15-arm64-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260105.0094
```